### PR TITLE
Add timeInForce option to place order options

### DIFF
--- a/api.go
+++ b/api.go
@@ -103,12 +103,13 @@ func ParseOrderParameter(opts ...OrderOption) *OrderParameter {
 }
 
 type PlaceOrderParameter struct {
-	BasePrice  float64
-	StopPx     float64
-	PostOnly   bool
-	ReduceOnly bool
-	PriceType  string
-	ClientOId  string
+	BasePrice   float64
+	StopPx      float64
+	PostOnly    bool
+	ReduceOnly  bool
+	PriceType   string
+	ClientOId   string
+	TimeInForce string
 }
 
 // 订单选项
@@ -152,6 +153,12 @@ func OrderPriceTypeOption(priceType string) PlaceOrderOption {
 func OrderClientOIdOption(clientOId string) PlaceOrderOption {
 	return func(p *PlaceOrderParameter) {
 		p.ClientOId = clientOId
+	}
+}
+
+func OrderTimeInForceOption(timeInForce string) PlaceOrderOption {
+	return func(p *PlaceOrderParameter) {
+		p.TimeInForce = timeInForce
 	}
 }
 

--- a/exchanges/binancefutures/binancefutures.go
+++ b/exchanges/binancefutures/binancefutures.go
@@ -207,10 +207,12 @@ func (b *BinanceFutures) PlaceOrder(symbol string, direction Direction, orderTyp
 		service = service.Price(fmt.Sprint(price))
 	}
 
+	if orderType != OrderTypeMarket {
+		service = service.TimeInForce(resolveTimeInForce(params.TimeInForce))
+	}
+
 	if params.PostOnly {
 		service = service.TimeInForce(futures.TimeInForceTypeGTX)
-	} else {
-		service = service.TimeInForce(resolveTimeInForce(params.TimeInForce))
 	}
 
 	service = service.Side(side).Type(_orderType)
@@ -225,6 +227,7 @@ func (b *BinanceFutures) PlaceOrder(symbol string, direction Direction, orderTyp
 
 func resolveTimeInForce(timeInForce string) futures.TimeInForceType {
 	var futuresTimeInForce futures.TimeInForceType
+
 	switch timeInForce {
 	case string(futures.TimeInForceTypeGTC):
 		futuresTimeInForce = futures.TimeInForceTypeGTC

--- a/exchanges/binancefutures/binancefutures.go
+++ b/exchanges/binancefutures/binancefutures.go
@@ -3,13 +3,14 @@ package binancefutures
 import (
 	"context"
 	"fmt"
-	"github.com/adshao/go-binance/futures"
-	. "github.com/coinrust/crex"
-	"github.com/coinrust/crex/utils"
 	"net/http"
 	"net/url"
 	"strconv"
 	"time"
+
+	"github.com/adshao/go-binance/futures"
+	. "github.com/coinrust/crex"
+	"github.com/coinrust/crex/utils"
 )
 
 // BinanceFutures the Binance futures exchange
@@ -205,9 +206,13 @@ func (b *BinanceFutures) PlaceOrder(symbol string, direction Direction, orderTyp
 	if price > 0 {
 		service = service.Price(fmt.Sprint(price))
 	}
+
 	if params.PostOnly {
 		service = service.TimeInForce(futures.TimeInForceTypeGTX)
+	} else {
+		service = service.TimeInForce(resolveTimeInForce(params.TimeInForce))
 	}
+
 	service = service.Side(side).Type(_orderType)
 	var res *futures.CreateOrderResponse
 	res, err = service.Do(context.Background())
@@ -216,6 +221,24 @@ func (b *BinanceFutures) PlaceOrder(symbol string, direction Direction, orderTyp
 	}
 	result = b.convertOrder1(res)
 	return
+}
+
+func resolveTimeInForce(timeInForce string) futures.TimeInForceType {
+	var futuresTimeInForce futures.TimeInForceType
+	switch timeInForce {
+	case string(futures.TimeInForceTypeGTC):
+		futuresTimeInForce = futures.TimeInForceTypeGTC
+	case string(futures.TimeInForceTypeFOK):
+		futuresTimeInForce = futures.TimeInForceTypeFOK
+	case string(futures.TimeInForceTypeIOC):
+		futuresTimeInForce = futures.TimeInForceTypeIOC
+	case string(futures.TimeInForceTypeGTX):
+		futuresTimeInForce = futures.TimeInForceTypeGTX
+	default:
+		futuresTimeInForce = futures.TimeInForceTypeGTC
+	}
+
+	return futuresTimeInForce
 }
 
 func (b *BinanceFutures) GetOpenOrders(symbol string, opts ...OrderOption) (result []*Order, err error) {


### PR DESCRIPTION
Hi @frankrap, 

I could not open a long order to Binance Futures and I got the following error message:
> <APIError> code=-1102, msg=Mandatory parameter 'timeInForce' was not sent, was empty/null, or malformed."

So I added the time in force as "GTC" as default and added the option to add time in force via the place order options.
Doing so fixed it and I could place orders.
Kindly let me know if this PR is ok for you or you find a better way to fix this.

Thanks!

Evandro