### PR TITLE
Fix DepthOrderBook.GetOrderBook

### DIFF
--- a/exchanges/deribit/orderbook.go
+++ b/exchanges/deribit/orderbook.go
@@ -106,7 +106,7 @@ func (d *DepthOrderBook) GetOrderBook(depth int) (result OrderBook) {
 		node := smallest
 		for count < depth {
 			node = d.asks.Next(node)
-			if node == nil {
+			if node == smallest {
 				break
 			}
 			item := node.GetValue().(DobItem)
@@ -129,7 +129,7 @@ func (d *DepthOrderBook) GetOrderBook(depth int) (result OrderBook) {
 		node := largest
 		for count < depth {
 			node = d.bids.Prev(node)
-			if node == nil {
+			if node == largest {
 				break
 			}
 			item := node.GetValue().(DobItem)

--- a/exchanges/hbdm/orderbook.go
+++ b/exchanges/hbdm/orderbook.go
@@ -108,7 +108,7 @@ func (d *DepthOrderBook) GetOrderBook(depth int) (result OrderBook) {
 		node := smallest
 		for count < depth {
 			node = d.asks.Next(node)
-			if node == nil {
+			if node == smallest {
 				break
 			}
 			item := node.GetValue().(DobItem)
@@ -131,7 +131,7 @@ func (d *DepthOrderBook) GetOrderBook(depth int) (result OrderBook) {
 		node := largest
 		for count < depth {
 			node = d.bids.Prev(node)
-			if node == nil {
+			if node == largest {
 				break
 			}
 			item := node.GetValue().(DobItem)

--- a/exchanges/hbdmswap/orderbook.go
+++ b/exchanges/hbdmswap/orderbook.go
@@ -108,7 +108,7 @@ func (d *DepthOrderBook) GetOrderBook(depth int) (result OrderBook) {
 		node := smallest
 		for count < depth {
 			node = d.asks.Next(node)
-			if node == nil {
+			if node == smallest {
 				break
 			}
 			item := node.GetValue().(DobItem)
@@ -131,7 +131,7 @@ func (d *DepthOrderBook) GetOrderBook(depth int) (result OrderBook) {
 		node := largest
 		for count < depth {
 			node = d.bids.Prev(node)
-			if node == nil {
+			if node == largest {
 				break
 			}
 			item := node.GetValue().(DobItem)


### PR DESCRIPTION
> // Next returns the next element based on the given node.
// Next will loop around to the first node, if you call it on the last!

as the above [document](https://github.com/MauriceGit/skiplist/blob/master/skiplist.go#L438) of `SkipList.Next` said, we can't use nil to determine where is the end.